### PR TITLE
Add wildcard to AWS partition in ARN validation

### DIFF
--- a/templates/boundary_custom_data.sh.tpl
+++ b/templates/boundary_custom_data.sh.tpl
@@ -234,7 +234,7 @@ function retrieve_license_from_awsssm {
   if [[ -z "$SECRET_ARN" ]]; then
     log "ERROR" "Secret ARN cannot be empty. Exiting."
     exit_script 4
-  elif [[ "$SECRET_ARN" == arn:aws:secretsmanager:* ]]; then
+  elif [[ "$SECRET_ARN" == arn:aws*:secretsmanager:* ]]; then
     log "INFO" "Retrieving value of secret '$SECRET_ARN' from AWS Secrets Manager."
     BOUNDARY_LICENSE=$(aws secretsmanager get-secret-value --region $SECRET_REGION --secret-id $SECRET_ARN --query SecretString --output text)
     echo "$BOUNDARY_LICENSE" >$BOUNDARY_LICENSE_PATH
@@ -256,7 +256,7 @@ function retrieve_certs_from_awssm {
   if [[ -z "$SECRET_ARN" ]]; then
     log "ERROR" "Secret ARN cannot be empty. Exiting."
     exit_script 5
-  elif [[ "$SECRET_ARN" == arn:aws:secretsmanager:* ]]; then
+  elif [[ "$SECRET_ARN" == arn:aws*:secretsmanager:* ]]; then
     log "INFO" "Retrieving value of secret '$SECRET_ARN' from AWS Secrets Manager."
     CERT_DATA=$(aws secretsmanager get-secret-value --region $SECRET_REGION --secret-id $SECRET_ARN --query SecretString --output text)
     echo "$CERT_DATA" | base64 -d >$DESTINATION_PATH


### PR DESCRIPTION
## Description
Allowing for valid [ARN partitions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html) in user data script by updating the ARN validation pattern from `arn:aws:secretsmanager:*` to `arn:aws*:secretsmanager:*`.

This ensures compatibility with:
- `arn:aws:` (commercial regions)
- `arn:aws-us-gov:` (GovCloud regions)
- `arn:aws-cn:` (China regions)

## Related issue
Related to hashicorp/terraform-aws-terraform-enterprise-hvd#42 and hashicorp/terraform-aws-terraform-enterprise-hvd#43

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
- Pattern matching validated to support commercial and GovCloud ARN formats

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Consistent with fixes in other HashiCorp HVD modules